### PR TITLE
Fix signature dialog drawing area

### DIFF
--- a/lib/screens/ecoce/shared/widgets/signature_dialog.dart
+++ b/lib/screens/ecoce/shared/widgets/signature_dialog.dart
@@ -80,8 +80,8 @@ class _SignatureDialogState extends State<SignatureDialog> {
     return AlertDialog(
       title: Text(widget.title),
       content: Container(
-        width: MediaQuery.of(context).size.width * 0.9,
-        height: 300,
+        width: MediaQuery.of(context).size.width * 0.95,
+        height: 400,
         decoration: BoxDecoration(
           border: Border.all(color: BioWayColors.lightGrey),
           borderRadius: BorderRadius.circular(8),
@@ -93,10 +93,7 @@ class _SignatureDialogState extends State<SignatureDialog> {
             GestureDetector(
               onPanUpdate: (details) {
                 setState(() {
-                  RenderBox renderBox = context.findRenderObject() as RenderBox;
-                  _tempSignaturePoints.add(
-                    renderBox.globalToLocal(details.globalPosition),
-                  );
+                  _tempSignaturePoints.add(details.localPosition);
                 });
               },
               onPanEnd: (details) {


### PR DESCRIPTION
## Summary
- ensure drawing points are recorded relative to the paint area
- enlarge the signature dialog so users have more space

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68794aca42048322b5a4245f0423420c