### PR TITLE
Fix signature dialog and reuse shared widgets

### DIFF
--- a/lib/screens/ecoce/origen/origen_crear_lote_screen.dart
+++ b/lib/screens/ecoce/origen/origen_crear_lote_screen.dart
@@ -3,8 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'dart:io';
 import '../../../utils/colors.dart';
-import '../../../services/image_service.dart';
-import '../reciclador/widgets/image_preview.dart';
+import '../shared/widgets/photo_evidence_widget.dart';
 import '../shared/widgets/signature_dialog.dart';
 import 'origen_lote_detalle_screen.dart';
 
@@ -41,9 +40,8 @@ class _OrigenCrearLoteScreenState extends State<OrigenCrearLoteScreen> {
   List<Offset?> _signaturePoints = [];
   bool _hasSignature = false;
   
-  // Variables para la imagen
-  File? _selectedImage;
-  bool _hasImage = false;
+  // Evidencia fotográfica
+  List<File> _photos = [];
 
 
   @override
@@ -76,149 +74,6 @@ class _OrigenCrearLoteScreenState extends State<OrigenCrearLoteScreen> {
     );
   }
 
-  void _showImageOptions() {
-    showModalBottomSheet(
-      context: context,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-      ),
-      builder: (BuildContext context) {
-        return Container(
-          padding: const EdgeInsets.all(20),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Text(
-                'Seleccionar imagen',
-                style: TextStyle(
-                  fontSize: 18,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              const SizedBox(height: 20),
-              ListTile(
-                leading: Icon(Icons.camera_alt, color: BioWayColors.ecoceGreen),
-                title: const Text('Tomar foto'),
-                onTap: () {
-                  Navigator.pop(context);
-                  _takePhoto();
-                },
-              ),
-              ListTile(
-                leading: Icon(Icons.photo_library, color: BioWayColors.ecoceGreen),
-                title: const Text('Seleccionar de galería'),
-                onTap: () {
-                  Navigator.pop(context);
-                  _selectFromGallery();
-                },
-              ),
-              if (_hasImage)
-                ListTile(
-                  leading: Icon(Icons.delete, color: BioWayColors.error),
-                  title: const Text('Eliminar imagen'),
-                  onTap: () {
-                    Navigator.pop(context);
-                    setState(() {
-                      _selectedImage = null;
-                      _hasImage = false;
-                    });
-                  },
-                ),
-            ],
-          ),
-        );
-      },
-    );
-  }
-
-  void _takePhoto() async {
-    try {
-      final File? photo = await ImageService.takePhoto();
-      if (photo != null && mounted) {
-        setState(() {
-          _selectedImage = photo;
-          _hasImage = true;
-        });
-        
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: const Text('Foto capturada correctamente'),
-              backgroundColor: BioWayColors.success,
-              behavior: SnackBarBehavior.floating,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(10),
-              ),
-            ),
-          );
-        }
-      }
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: const Text('Error al acceder a la cámara'),
-            backgroundColor: BioWayColors.error,
-            behavior: SnackBarBehavior.floating,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(10),
-            ),
-          ),
-        );
-      }
-    }
-  }
-
-  void _selectFromGallery() async {
-    try {
-      final File? image = await ImageService.pickFromGallery();
-      if (image != null && mounted) {
-        setState(() {
-          _selectedImage = image;
-          _hasImage = true;
-        });
-        
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: const Text('Imagen seleccionada correctamente'),
-              backgroundColor: BioWayColors.success,
-              behavior: SnackBarBehavior.floating,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(10),
-              ),
-            ),
-          );
-        }
-      }
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: const Text('Error al acceder a la galería'),
-            backgroundColor: BioWayColors.error,
-            behavior: SnackBarBehavior.floating,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(10),
-            ),
-          ),
-        );
-      }
-    }
-  }
-
-  void _showErrorSnackBar(String message) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(message),
-        backgroundColor: BioWayColors.error,
-        behavior: SnackBarBehavior.floating,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(10),
-        ),
-      ),
-    );
-  }
 
   void _generarLote() {
     // Sin validaciones - Solo para diseño visual
@@ -488,7 +343,20 @@ class _OrigenCrearLoteScreenState extends State<OrigenCrearLoteScreen> {
                       icon: '📷',
                       title: 'Evidencia Fotográfica',
                       children: [
-                        _buildImageArea(),
+                        PhotoEvidenceWidget(
+                          maxPhotos: 1,
+                          minPhotos: 1,
+                          showCounter: false,
+                          primaryColor: BioWayColors.ecoceGreen,
+                          onPhotosChanged: (photos) {
+                            setState(() {
+                              _photos = photos;
+                            });
+                          },
+                          addPhotoText: 'Agregar evidencia',
+                          emptyStateText: 'Agregar evidencia',
+                          emptyStateSubtext: 'Toca para tomar foto o seleccionar',
+                        ),
                       ],
                     ),
                     
@@ -754,147 +622,6 @@ class _OrigenCrearLoteScreenState extends State<OrigenCrearLoteScreen> {
                 ),
               ),
             ),
-    );
-  }
-
-  Widget _buildImageArea() {
-    return InkWell(
-      onTap: _showImageOptions,
-      borderRadius: BorderRadius.circular(12),
-      child: Container(
-        height: 200,
-        width: double.infinity,
-        decoration: BoxDecoration(
-          color: BioWayColors.backgroundGrey,
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(
-            color: _hasImage
-                ? BioWayColors.ecoceGreen
-                : BioWayColors.ecoceGreen.withOpacity(0.3),
-            width: _hasImage ? 2 : 1,
-          ),
-        ),
-        child: _hasImage && _selectedImage != null
-            ? ClipRRect(
-                borderRadius: BorderRadius.circular(11),
-                child: Stack(
-                  children: [
-                    GestureDetector(
-                      onTap: () {
-                        // Mostrar imagen en pantalla completa
-                        showDialog(
-                          context: context,
-                          builder: (context) => ImagePreviewDialog(
-                            image: _selectedImage!,
-                            title: 'Evidencia fotográfica',
-                          ),
-                        );
-                      },
-                      child: Image.file(
-                        _selectedImage!,
-                        width: double.infinity,
-                        height: double.infinity,
-                        fit: BoxFit.cover,
-                      ),
-                    ),
-                    Positioned(
-                      top: 8,
-                      right: 8,
-                      child: Row(
-                        children: [
-                          Container(
-                            decoration: BoxDecoration(
-                              color: Colors.white,
-                              borderRadius: BorderRadius.circular(20),
-                              boxShadow: [
-                                BoxShadow(
-                                  color: Colors.black.withOpacity(0.2),
-                                  blurRadius: 4,
-                                ),
-                              ],
-                            ),
-                            child: IconButton(
-                              onPressed: () {
-                                showDialog(
-                                  context: context,
-                                  builder: (context) => ImagePreviewDialog(
-                                    image: _selectedImage!,
-                                    title: 'Evidencia fotográfica',
-                                  ),
-                                );
-                              },
-                              icon: const Icon(
-                                Icons.fullscreen,
-                                color: Colors.grey,
-                                size: 20,
-                              ),
-                              constraints: const BoxConstraints(
-                                minWidth: 36,
-                                minHeight: 36,
-                              ),
-                              padding: EdgeInsets.zero,
-                            ),
-                          ),
-                          const SizedBox(width: 8),
-                          Container(
-                            decoration: BoxDecoration(
-                              color: Colors.white,
-                              borderRadius: BorderRadius.circular(20),
-                              boxShadow: [
-                                BoxShadow(
-                                  color: Colors.black.withOpacity(0.2),
-                                  blurRadius: 4,
-                                ),
-                              ],
-                            ),
-                            child: IconButton(
-                              onPressed: _showImageOptions,
-                              icon: Icon(
-                                Icons.edit,
-                                color: BioWayColors.ecoceGreen,
-                                size: 20,
-                              ),
-                              constraints: const BoxConstraints(
-                                minWidth: 36,
-                                minHeight: 36,
-                              ),
-                              padding: EdgeInsets.zero,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ],
-                ),
-              )
-            : Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(
-                    Icons.add_a_photo,
-                    size: 50,
-                    color: BioWayColors.ecoceGreen.withOpacity(0.5),
-                  ),
-                  const SizedBox(height: 12),
-                  Text(
-                    'Agregar evidencia',
-                    style: TextStyle(
-                      fontSize: 16,
-                      color: BioWayColors.ecoceGreen,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    'Toca para tomar foto o seleccionar',
-                    style: TextStyle(
-                      fontSize: 12,
-                      color: Colors.grey[600],
-                    ),
-                  ),
-                ],
-              ),
-      ),
     );
   }
 

--- a/lib/screens/ecoce/shared/widgets/signature_dialog.dart
+++ b/lib/screens/ecoce/shared/widgets/signature_dialog.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import '../../../../utils/colors.dart';
 
-/// A reusable signature dialog widget that allows users to draw their signature
+/// Dialogo reutilizable para capturar firmas dibujando sobre el lienzo.
 class SignatureDialog extends StatefulWidget {
   final String title;
   final List<Offset?> initialSignature;
-  final Function(List<Offset?>) onSignatureSaved;
+  final ValueChanged<List<Offset?>> onSignatureSaved;
   final Color primaryColor;
 
   const SignatureDialog({
@@ -13,23 +13,20 @@ class SignatureDialog extends StatefulWidget {
     this.title = 'Firma del Responsable',
     required this.initialSignature,
     required this.onSignatureSaved,
-    this.primaryColor = const Color(0xFF2E3A59), // BioWayColors.deepBlue
+    this.primaryColor = const Color(0xFF2E3A59),
   });
 
-  @override
-  State<SignatureDialog> createState() => _SignatureDialogState();
-
-  /// Static method to show the signature dialog
+  /// Muestra el diálogo de firma.
   static Future<void> show({
     required BuildContext context,
     String title = 'Firma del Responsable',
     required List<Offset?> initialSignature,
-    required Function(List<Offset?>) onSignatureSaved,
+    required ValueChanged<List<Offset?>> onSignatureSaved,
     Color? primaryColor,
   }) {
     return showDialog(
       context: context,
-      builder: (context) => SignatureDialog(
+      builder: (_) => SignatureDialog(
         title: title,
         initialSignature: initialSignature,
         onSignatureSaved: onSignatureSaved,
@@ -37,42 +34,54 @@ class SignatureDialog extends StatefulWidget {
       ),
     );
   }
+
+  @override
+  State<SignatureDialog> createState() => _SignatureDialogState();
 }
 
 class _SignatureDialogState extends State<SignatureDialog> {
-  late List<Offset?> _tempSignaturePoints;
+  late List<Offset?> _points;
 
   @override
   void initState() {
     super.initState();
-    _tempSignaturePoints = List.from(widget.initialSignature);
+    _points = List.of(widget.initialSignature);
   }
 
-  void _clearSignature() {
+  void _onPanUpdate(DragUpdateDetails details) {
     setState(() {
-      _tempSignaturePoints.clear();
+      _points.add(details.localPosition);
     });
   }
 
-  void _saveSignature() {
-    widget.onSignatureSaved(_tempSignaturePoints);
+  void _onPanEnd(DragEndDetails details) {
+    setState(() {
+      _points.add(null);
+    });
+  }
+
+  void _clear() {
+    setState(() {
+      _points.clear();
+    });
+  }
+
+  void _cancel() {
     Navigator.of(context).pop();
-    
-    // Show success message
+  }
+
+  void _save() {
+    widget.onSignatureSaved(List.of(_points));
+    Navigator.of(context).pop();
+
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: const Text('Firma guardada correctamente'),
         backgroundColor: BioWayColors.success,
         behavior: SnackBarBehavior.floating,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(10),
-        ),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
       ),
     );
-  }
-
-  void _cancel() {
-    Navigator.of(context).pop();
   }
 
   @override
@@ -83,72 +92,45 @@ class _SignatureDialogState extends State<SignatureDialog> {
         width: MediaQuery.of(context).size.width * 0.95,
         height: 400,
         decoration: BoxDecoration(
+          color: Colors.grey[50],
           border: Border.all(color: BioWayColors.lightGrey),
           borderRadius: BorderRadius.circular(8),
-          color: Colors.grey[50],
         ),
-        child: Stack(
-          children: [
-            // Signature drawing area
-            GestureDetector(
-              onPanUpdate: (details) {
-                setState(() {
-                  _tempSignaturePoints.add(details.localPosition);
-                });
-              },
-              onPanEnd: (details) {
-                _tempSignaturePoints.add(null); // Add null to separate stroke paths
-              },
-              child: CustomPaint(
-                painter: SignaturePainter(_tempSignaturePoints),
-                size: Size.infinite,
-              ),
-            ),
-            // Placeholder when no signature
-            if (_tempSignaturePoints.isEmpty)
-              Center(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Icon(
-                      Icons.draw,
-                      size: 48,
-                      color: Colors.grey[400],
+        child: GestureDetector(
+          onPanUpdate: _onPanUpdate,
+          onPanEnd: _onPanEnd,
+          child: CustomPaint(
+            painter: SignaturePainter(List.of(_points)),
+            size: Size.infinite,
+            child: _points.isEmpty
+                ? Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(Icons.draw, size: 48, color: Colors.grey[400]),
+                        const SizedBox(height: 8),
+                        Text(
+                          'Dibuja tu firma aquí',
+                          style: TextStyle(color: Colors.grey[600], fontSize: 16),
+                        ),
+                      ],
                     ),
-                    const SizedBox(height: 8),
-                    Text(
-                      'Dibuja tu firma aquí',
-                      style: TextStyle(
-                        color: Colors.grey[600],
-                        fontSize: 16,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-          ],
+                  )
+                : null,
+          ),
         ),
       ),
       actions: [
-        // Clear button
         TextButton(
-          onPressed: _clearSignature,
-          child: Text(
-            'Limpiar',
-            style: TextStyle(color: BioWayColors.error),
-          ),
+          onPressed: _clear,
+          child: Text('Limpiar', style: TextStyle(color: BioWayColors.error)),
         ),
-        // Cancel button
         TextButton(
           onPressed: _cancel,
-          child: const Text(
-            'Cancelar',
-            style: TextStyle(color: Colors.grey),
-          ),
+          child: const Text('Cancelar', style: TextStyle(color: Colors.grey)),
         ),
-        // Save button
         ElevatedButton(
-          onPressed: _tempSignaturePoints.isNotEmpty ? _saveSignature : null,
+          onPressed: _points.isNotEmpty ? _save : null,
           style: ElevatedButton.styleFrom(
             backgroundColor: widget.primaryColor,
             foregroundColor: Colors.white,
@@ -160,11 +142,10 @@ class _SignatureDialogState extends State<SignatureDialog> {
   }
 }
 
-/// Custom painter for drawing the signature
 class SignaturePainter extends CustomPainter {
   final List<Offset?> points;
 
-  const SignaturePainter(this.points);
+  SignaturePainter(this.points);
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -181,7 +162,8 @@ class SignaturePainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(SignaturePainter oldDelegate) {
-    return oldDelegate.points != points;
+  bool shouldRepaint(covariant SignaturePainter oldDelegate) {
+    return oldDelegate.points.length != points.length;
   }
 }
+


### PR DESCRIPTION
## Summary
- refactor `origen_crear_lote_screen.dart` to use `PhotoEvidenceWidget`
- cleanup unused imports
- ensure signature dialog repaints during drawing

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68794d000e9c8322bf225fee5efdaccc