### PR TITLE
Enable customized plant login

### DIFF
--- a/lib/screens/ecoce/origen/origen_ayuda.dart
+++ b/lib/screens/ecoce/origen/origen_ayuda.dart
@@ -3,15 +3,17 @@ import '../../../utils/colors.dart';
 import '../../../utils/optimized_navigation.dart';
 import '../shared/placeholder_ayuda_screen.dart';
 import 'widgets/origen_bottom_navigation.dart';
+import 'origen_config.dart';
 
 class OrigenAyudaScreen extends StatelessWidget {
   const OrigenAyudaScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final config = OrigenUserConfig.current;
     return PlaceholderAyudaScreen(
-      tipoUsuario: 'Centro de Acopio',
-      primaryColor: BioWayColors.ecoceGreen,
+      tipoUsuario: config.tipoUsuario,
+      primaryColor: config.color,
       bottomNavigation: OrigenBottomNavigation(
         selectedIndex: 2,
         onItemTapped: (index) {

--- a/lib/screens/ecoce/origen/origen_config.dart
+++ b/lib/screens/ecoce/origen/origen_config.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import '../../../utils/colors.dart';
+
+class OrigenUserConfig {
+  final String nombre;
+  final String folio;
+  final String tipoUsuario;
+  final Color color;
+
+  const OrigenUserConfig({
+    required this.nombre,
+    required this.folio,
+    required this.tipoUsuario,
+    required this.color,
+  });
+
+  static const OrigenUserConfig acopiador = OrigenUserConfig(
+    nombre: 'Centro de Acopio La Esperanza',
+    folio: 'A0000001',
+    tipoUsuario: 'Centro de Acopio',
+    color: BioWayColors.ecoceGreen,
+  );
+
+  static const OrigenUserConfig planta = OrigenUserConfig(
+    nombre: 'Planta de Separación La Esperanza',
+    folio: 'P0000001',
+    tipoUsuario: 'Planta de Separación',
+    color: BioWayColors.hdpeGreen,
+  );
+
+  static OrigenUserConfig current = acopiador;
+}

--- a/lib/screens/ecoce/origen/origen_crear_lote_screen.dart
+++ b/lib/screens/ecoce/origen/origen_crear_lote_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'dart:io';
 import '../../../utils/colors.dart';
+import 'origen_config.dart';
 import '../shared/widgets/signature_dialog.dart';
 import '../shared/widgets/photo_evidence_widget.dart';
 import 'origen_lote_detalle_screen.dart';
@@ -16,6 +17,8 @@ class OrigenCrearLoteScreen extends StatefulWidget {
 
 class _OrigenCrearLoteScreenState extends State<OrigenCrearLoteScreen> {
   final _formKey = GlobalKey<FormState>();
+
+  Color get _primaryColor => OrigenUserConfig.current.color;
   
   // Controladores para los campos de texto
   final TextEditingController _fuenteController = TextEditingController();
@@ -67,7 +70,7 @@ class _OrigenCrearLoteScreenState extends State<OrigenCrearLoteScreen> {
           _hasSignature = points.isNotEmpty;
         });
       },
-      primaryColor: BioWayColors.ecoceGreen,
+      primaryColor: _primaryColor,
     );
   }
 
@@ -102,7 +105,7 @@ class _OrigenCrearLoteScreenState extends State<OrigenCrearLoteScreen> {
     return Scaffold(
       backgroundColor: BioWayColors.backgroundGrey,
       appBar: AppBar(
-        backgroundColor: BioWayColors.ecoceGreen,
+        backgroundColor: _primaryColor,
         elevation: 0,
         leading: IconButton(
           icon: const Icon(Icons.arrow_back_ios, color: Colors.white),
@@ -127,7 +130,7 @@ class _OrigenCrearLoteScreenState extends State<OrigenCrearLoteScreen> {
             width: double.infinity,
             padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
             decoration: BoxDecoration(
-              color: BioWayColors.ecoceGreen,
+              color: _primaryColor,
               borderRadius: const BorderRadius.only(
                 bottomLeft: Radius.circular(30),
                 bottomRight: Radius.circular(30),
@@ -271,10 +274,10 @@ class _OrigenCrearLoteScreenState extends State<OrigenCrearLoteScreen> {
                             Container(
                               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
                               decoration: BoxDecoration(
-                                color: BioWayColors.ecoceGreen.withOpacity(0.1),
+                                color: _primaryColor.withOpacity(0.1),
                                 borderRadius: BorderRadius.circular(12),
                                 border: Border.all(
-                                  color: BioWayColors.ecoceGreen.withOpacity(0.3),
+                                  color: _primaryColor.withOpacity(0.3),
                                   width: 1,
                                 ),
                               ),
@@ -283,7 +286,7 @@ class _OrigenCrearLoteScreenState extends State<OrigenCrearLoteScreen> {
                                 style: TextStyle(
                                   fontSize: 16,
                                   fontWeight: FontWeight.bold,
-                                  color: BioWayColors.ecoceGreen,
+                                  color: _primaryColor,
                                 ),
                               ),
                             ),
@@ -342,7 +345,7 @@ class _OrigenCrearLoteScreenState extends State<OrigenCrearLoteScreen> {
                       maxPhotos: 1,
                       minPhotos: 0,
                       onPhotosChanged: (_) {},
-                      primaryColor: BioWayColors.ecoceGreen,
+                      primaryColor: _primaryColor,
                     ),
                     
                     const SizedBox(height: 20),
@@ -372,7 +375,7 @@ class _OrigenCrearLoteScreenState extends State<OrigenCrearLoteScreen> {
                       child: ElevatedButton(
                         onPressed: _generarLote,
                         style: ElevatedButton.styleFrom(
-                          backgroundColor: BioWayColors.ecoceGreen,
+                          backgroundColor: _primaryColor,
                           foregroundColor: Colors.white,
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(28),
@@ -469,14 +472,14 @@ class _OrigenCrearLoteScreenState extends State<OrigenCrearLoteScreen> {
       enabledBorder: OutlineInputBorder(
         borderRadius: BorderRadius.circular(12),
         borderSide: BorderSide(
-          color: BioWayColors.ecoceGreen.withOpacity(0.3),
+          color: _primaryColor.withOpacity(0.3),
           width: 1,
         ),
       ),
       focusedBorder: OutlineInputBorder(
         borderRadius: BorderRadius.circular(12),
         borderSide: BorderSide(
-          color: BioWayColors.ecoceGreen,
+          color: _primaryColor,
           width: 2,
         ),
       ),
@@ -493,8 +496,8 @@ class _OrigenCrearLoteScreenState extends State<OrigenCrearLoteScreen> {
             : BioWayColors.backgroundGrey,
         border: Border.all(
           color: _hasSignature 
-              ? BioWayColors.ecoceGreen 
-              : BioWayColors.ecoceGreen.withOpacity(0.3),
+              ? _primaryColor 
+              : _primaryColor.withOpacity(0.3),
           width: 1,
         ),
         borderRadius: BorderRadius.circular(12),
@@ -562,7 +565,7 @@ class _OrigenCrearLoteScreenState extends State<OrigenCrearLoteScreen> {
                           onPressed: _showSignatureDialog,
                           icon: Icon(
                             Icons.edit,
-                            color: BioWayColors.ecoceGreen,
+                            color: _primaryColor,
                             size: 20,
                           ),
                           constraints: const BoxConstraints(
@@ -591,7 +594,7 @@ class _OrigenCrearLoteScreenState extends State<OrigenCrearLoteScreen> {
                   children: [
                     Icon(
                       Icons.edit,
-                      color: BioWayColors.ecoceGreen,
+                      color: _primaryColor,
                       size: 24,
                     ),
                     const SizedBox(width: 12),
@@ -600,7 +603,7 @@ class _OrigenCrearLoteScreenState extends State<OrigenCrearLoteScreen> {
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.bold,
-                        color: BioWayColors.ecoceGreen,
+                        color: _primaryColor,
                       ),
                     ),
                   ],
@@ -622,10 +625,10 @@ class _OrigenCrearLoteScreenState extends State<OrigenCrearLoteScreen> {
       child: Container(
         padding: const EdgeInsets.symmetric(vertical: 20),
         decoration: BoxDecoration(
-          color: isSelected ? BioWayColors.ecoceGreen.withOpacity(0.1) : BioWayColors.backgroundGrey,
+          color: isSelected ? _primaryColor.withOpacity(0.1) : BioWayColors.backgroundGrey,
           borderRadius: BorderRadius.circular(12),
           border: Border.all(
-            color: isSelected ? BioWayColors.ecoceGreen : BioWayColors.ecoceGreen.withOpacity(0.3),
+            color: isSelected ? _primaryColor : _primaryColor.withOpacity(0.3),
             width: isSelected ? 2 : 1,
           ),
         ),
@@ -642,7 +645,7 @@ class _OrigenCrearLoteScreenState extends State<OrigenCrearLoteScreen> {
               style: TextStyle(
                 fontSize: 16,
                 fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
-                color: isSelected ? BioWayColors.ecoceGreen : BioWayColors.textGrey,
+                color: isSelected ? _primaryColor : BioWayColors.textGrey,
               ),
             ),
           ],

--- a/lib/screens/ecoce/origen/origen_inicio_screen.dart
+++ b/lib/screens/ecoce/origen/origen_inicio_screen.dart
@@ -9,6 +9,7 @@ import 'origen_perfil.dart';
 import 'origen_lote_detalle_screen.dart';
 import '../shared/widgets/lote_card.dart';
 import 'widgets/origen_bottom_navigation.dart';
+import 'origen_config.dart';
 
 class OrigenInicioScreen extends StatefulWidget {
   const OrigenInicioScreen({super.key});
@@ -21,9 +22,11 @@ class _OrigenInicioScreenState extends State<OrigenInicioScreen> {
   // Índice para la navegación del bottom bar
   final int _selectedIndex = 0;
 
-  // Datos del centro de acopio (en producción vendrían de la base de datos)
-  final String _nombreCentro = "Centro de Acopio La Esperanza";
-  final String _folioCentro = "A0000001";
+  String get _nombreCentro => OrigenUserConfig.current.nombre;
+  String get _folioCentro => OrigenUserConfig.current.folio;
+  String get _tipoCentro => OrigenUserConfig.current.tipoUsuario;
+  Color get _primaryColor => OrigenUserConfig.current.color;
+
   final int _lotesCreados = 127;
   final double _materialProcesado = 4.5; // en toneladas
 
@@ -232,8 +235,8 @@ class _OrigenInicioScreenState extends State<OrigenInicioScreen> {
                     begin: Alignment.topLeft,
                     end: Alignment.bottomRight,
                     colors: [
-                      BioWayColors.ecoceGreen,
-                      BioWayColors.ecoceGreen.withOpacity(0.8),
+                      _primaryColor,
+                      _primaryColor.withOpacity(0.8),
                     ],
                   ),
                 ),
@@ -340,15 +343,15 @@ class _OrigenInicioScreenState extends State<OrigenInicioScreen> {
                                     Icon(
                                       Icons.store,
                                       size: 16,
-                                      color: BioWayColors.ecoceGreen,
+                                      color: _primaryColor,
                                     ),
                                     const SizedBox(width: 6),
                                     Text(
-                                      'Centro de Acopio',
+                                      _tipoCentro,
                                       style: TextStyle(
                                         fontSize: 13,
                                         fontWeight: FontWeight.w600,
-                                        color: BioWayColors.ecoceGreen,
+                                        color: _primaryColor,
                                       ),
                                     ),
                                   ],
@@ -621,14 +624,14 @@ class _OrigenInicioScreenState extends State<OrigenInicioScreen> {
                               begin: Alignment.topLeft,
                               end: Alignment.bottomRight,
                               colors: [
-                                BioWayColors.ecoceGreen,
-                                BioWayColors.ecoceGreen.withOpacity(0.8),
+                                _primaryColor,
+                                _primaryColor.withOpacity(0.8),
                               ],
                             ),
                             borderRadius: BorderRadius.circular(16),
                             boxShadow: [
                               BoxShadow(
-                                color: BioWayColors.ecoceGreen.withOpacity(0.3),
+                                color: _primaryColor.withOpacity(0.3),
                                 blurRadius: 12,
                                 offset: const Offset(0, 6),
                               ),
@@ -716,7 +719,7 @@ class _OrigenInicioScreenState extends State<OrigenInicioScreen> {
                                     'Ver todos',
                                     style: TextStyle(
                                       fontSize: 14,
-                                      color: BioWayColors.ecoceGreen,
+                                      color: _primaryColor,
                                       fontWeight: FontWeight.w600,
                                     ),
                                   ),
@@ -724,7 +727,7 @@ class _OrigenInicioScreenState extends State<OrigenInicioScreen> {
                                   Icon(
                                     Icons.arrow_forward,
                                     size: 16,
-                                    color: BioWayColors.ecoceGreen,
+                                    color: _primaryColor,
                                   ),
                                 ],
                               ),

--- a/lib/screens/ecoce/origen/origen_lote_detalle_screen.dart
+++ b/lib/screens/ecoce/origen/origen_lote_detalle_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import '../../../utils/colors.dart';
+import 'origen_config.dart';
 import 'origen_inicio_screen.dart';
 import '../shared/widgets/lote_card.dart';
 import '../shared/widgets/qr_code_display_widget.dart';
@@ -31,11 +32,13 @@ class OrigenLoteDetalleScreen extends StatefulWidget {
   State<OrigenLoteDetalleScreen> createState() => _OrigenLoteDetalleScreenState();
 }
 
-class _OrigenLoteDetalleScreenState extends State<OrigenLoteDetalleScreen> 
+class _OrigenLoteDetalleScreenState extends State<OrigenLoteDetalleScreen>
     with SingleTickerProviderStateMixin {
   late AnimationController _animationController;
   late Animation<double> _scaleAnimation;
   late Animation<double> _fadeAnimation;
+
+  Color get _primaryColor => OrigenUserConfig.current.color;
 
   @override
   void initState() {
@@ -264,7 +267,7 @@ class _OrigenLoteDetalleScreenState extends State<OrigenLoteDetalleScreen>
                 origen: widget.fuente,
                 fechaCreacion: widget.fechaCreacion,
                 titulo: 'Código QR del Lote',
-                colorPrincipal: BioWayColors.ecoceGreen,
+                colorPrincipal: _primaryColor,
                 tipoUsuario: 'origen',
                 onDescargar: _descargarCodigoQR,
                 onImprimir: _imprimirEtiqueta,
@@ -288,7 +291,7 @@ class _OrigenLoteDetalleScreenState extends State<OrigenLoteDetalleScreen>
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w600,
-                        color: BioWayColors.ecoceGreen,
+                        color: _primaryColor,
                       ),
                     ),
                   ),

--- a/lib/screens/ecoce/origen/origen_lotes_screen.dart
+++ b/lib/screens/ecoce/origen/origen_lotes_screen.dart
@@ -8,6 +8,7 @@ import 'origen_ayuda.dart';
 import 'origen_perfil.dart';
 import '../shared/widgets/lote_card.dart';
 import 'widgets/origen_bottom_navigation.dart';
+import 'origen_config.dart';
 
 class OrigenLotesScreen extends StatefulWidget {
   const OrigenLotesScreen({super.key});
@@ -19,6 +20,8 @@ class OrigenLotesScreen extends StatefulWidget {
 class _OrigenLotesScreenState extends State<OrigenLotesScreen> {
   // Índice para la navegación del bottom bar
   int _selectedIndex = 1; // Lotes está seleccionado
+
+  Color get _primaryColor => OrigenUserConfig.current.color;
 
   // Filtros
   String _filtroMaterial = 'Todos';
@@ -251,7 +254,7 @@ class _OrigenLotesScreenState extends State<OrigenLotesScreen> {
                         // Botón de filtros
                         Container(
                           decoration: BoxDecoration(
-                            color: BioWayColors.ecoceGreen.withOpacity(0.1),
+                            color: _primaryColor.withOpacity(0.1),
                             borderRadius: BorderRadius.circular(12),
                           ),
                           child: IconButton(
@@ -259,7 +262,7 @@ class _OrigenLotesScreenState extends State<OrigenLotesScreen> {
                               children: [
                                 Icon(
                                   Icons.filter_list,
-                                  color: BioWayColors.ecoceGreen,
+                                  color: _primaryColor,
                                 ),
                                 if (_filtroMaterial != 'Todos' || _filtroPresentacion != 'Todas')
                                   Positioned(
@@ -515,14 +518,14 @@ class _OrigenLotesScreenState extends State<OrigenLotesScreen> {
                             _filtroMaterial = material;
                           });
                         },
-                        selectedColor: BioWayColors.ecoceGreen,
+                        selectedColor: _primaryColor,
                         backgroundColor: Colors.grey[100],
                         labelStyle: TextStyle(
                           color: isSelected ? Colors.white : Colors.black87,
                           fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
                         ),
                         side: BorderSide(
-                          color: isSelected ? BioWayColors.ecoceGreen : Colors.transparent,
+                          color: isSelected ? _primaryColor : Colors.transparent,
                         ),
                       );
                     }).toList(),
@@ -561,14 +564,14 @@ class _OrigenLotesScreenState extends State<OrigenLotesScreen> {
                             _filtroPresentacion = presentacion;
                           });
                         },
-                        selectedColor: BioWayColors.ecoceGreen,
+                        selectedColor: _primaryColor,
                         backgroundColor: Colors.grey[100],
                         labelStyle: TextStyle(
                           color: isSelected ? Colors.white : Colors.black87,
                           fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
                         ),
                         side: BorderSide(
-                          color: isSelected ? BioWayColors.ecoceGreen : Colors.transparent,
+                          color: isSelected ? _primaryColor : Colors.transparent,
                         ),
                       );
                     }).toList(),
@@ -587,7 +590,7 @@ class _OrigenLotesScreenState extends State<OrigenLotesScreen> {
                     Navigator.pop(context);
                   },
                   style: ElevatedButton.styleFrom(
-                    backgroundColor: BioWayColors.ecoceGreen,
+                    backgroundColor: _primaryColor,
                     foregroundColor: Colors.white,
                     padding: const EdgeInsets.symmetric(vertical: 16),
                     shape: RoundedRectangleBorder(
@@ -625,7 +628,7 @@ class _OrigenLotesScreenState extends State<OrigenLotesScreen> {
               width: 120,
               height: 120,
               decoration: BoxDecoration(
-                color: BioWayColors.ecoceGreen.withOpacity(0.05),
+                color: _primaryColor.withOpacity(0.05),
                 shape: BoxShape.circle,
               ),
               child: Stack(
@@ -634,7 +637,7 @@ class _OrigenLotesScreenState extends State<OrigenLotesScreen> {
                   Icon(
                     Icons.inventory_2_outlined,
                     size: 60,
-                    color: BioWayColors.ecoceGreen.withOpacity(0.3),
+                    color: _primaryColor.withOpacity(0.3),
                   ),
                   Positioned(
                     right: 25,
@@ -695,7 +698,7 @@ class _OrigenLotesScreenState extends State<OrigenLotesScreen> {
                   });
                 },
                 style: OutlinedButton.styleFrom(
-                  side: BorderSide(color: BioWayColors.ecoceGreen),
+                  side: BorderSide(color: _primaryColor),
                   padding: const EdgeInsets.symmetric(
                     horizontal: 24,
                     vertical: 12,
@@ -707,7 +710,7 @@ class _OrigenLotesScreenState extends State<OrigenLotesScreen> {
                 child: Text(
                   'Limpiar búsqueda',
                   style: TextStyle(
-                    color: BioWayColors.ecoceGreen,
+                    color: _primaryColor,
                     fontWeight: FontWeight.w600,
                   ),
                 ),
@@ -718,7 +721,7 @@ class _OrigenLotesScreenState extends State<OrigenLotesScreen> {
                 icon: const Icon(Icons.add_circle_outline),
                 label: const Text('Crear nuevo lote'),
                 style: ElevatedButton.styleFrom(
-                  backgroundColor: BioWayColors.ecoceGreen,
+                  backgroundColor: _primaryColor,
                   foregroundColor: Colors.white,
                   padding: const EdgeInsets.symmetric(
                     horizontal: 24,

--- a/lib/screens/ecoce/origen/origen_perfil.dart
+++ b/lib/screens/ecoce/origen/origen_perfil.dart
@@ -1,19 +1,21 @@
 import 'package:flutter/material.dart';
 import '../../../utils/colors.dart';
 import '../shared/placeholder_perfil_screen.dart';
+import 'origen_config.dart';
 
 class OrigenPerfilScreen extends StatelessWidget {
   const OrigenPerfilScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final config = OrigenUserConfig.current;
     return PlaceholderPerfilScreen(
-      nombreUsuario: "Centro de Acopio La Esperanza",
-      tipoUsuario: "Centro de Acopio",
-      folioUsuario: "A0000001",
+      nombreUsuario: config.nombre,
+      tipoUsuario: config.tipoUsuario,
+      folioUsuario: config.folio,
       iconCode: "store",
-      primaryColor: BioWayColors.ecoceGreen,
-      nombreEmpresa: "Centro de Acopio La Esperanza S.A. de C.V.",
+      primaryColor: config.color,
+      nombreEmpresa: "${config.nombre} S.A. de C.V.",
     );
   }
 }

--- a/lib/screens/ecoce/origen/widgets/origen_bottom_navigation.dart
+++ b/lib/screens/ecoce/origen/widgets/origen_bottom_navigation.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import '../../../../utils/colors.dart';
+import '../origen_config.dart';
 
 class OrigenBottomNavigation extends StatelessWidget {
   final int selectedIndex;
@@ -69,7 +70,7 @@ class OrigenBottomNavigation extends StatelessWidget {
             children: [
               Icon(
                 isSelected ? activeIcon : icon,
-                color: isSelected ? BioWayColors.ecoceGreen : Colors.grey,
+                color: isSelected ? OrigenUserConfig.current.color : Colors.grey,
                 size: 24,
               ),
               const SizedBox(height: 4),
@@ -77,7 +78,7 @@ class OrigenBottomNavigation extends StatelessWidget {
                 label,
                 style: TextStyle(
                   fontSize: 11,
-                  color: isSelected ? BioWayColors.ecoceGreen : Colors.grey,
+                  color: isSelected ? OrigenUserConfig.current.color : Colors.grey,
                   fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
                 ),
               ),
@@ -106,13 +107,13 @@ class OrigenFloatingActionButton extends StatelessWidget {
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
           colors: [
-            BioWayColors.ecoceGreen,
-            BioWayColors.ecoceGreen.withOpacity(0.8),
+            OrigenUserConfig.current.color,
+            OrigenUserConfig.current.color.withOpacity(0.8),
           ],
         ),
         boxShadow: [
           BoxShadow(
-            color: BioWayColors.ecoceGreen.withOpacity(0.3),
+            color: OrigenUserConfig.current.color.withOpacity(0.3),
             blurRadius: 8,
             offset: const Offset(0, 4),
           ),

--- a/lib/screens/login/ecoce/ecoce_login_screen.dart
+++ b/lib/screens/login/ecoce/ecoce_login_screen.dart
@@ -5,6 +5,7 @@ import '../../../utils/colors.dart';
 import 'ecoce_tipo_proveedor_selector.dart';
 import '../../ecoce/reciclador/reciclador_inicio.dart';
 import '../../ecoce/reciclador/reciclador_perfil.dart';
+import '../../ecoce/origen/origen_config.dart';
 // TEMPORAL: Importar pantallas de inicio
 import '../../ecoce/origen/origen_inicio_screen.dart';
 import '../../ecoce/origen/origen_perfil.dart';
@@ -240,10 +241,12 @@ class _ECOCELoginScreenState extends State<ECOCELoginScreen>
         targetScreen = const RecicladorHomeScreen();
         break;
       case 'acopiador':
+        OrigenUserConfig.current = OrigenUserConfig.acopiador;
         targetScreen = const OrigenInicioScreen();
         break;
       case 'planta de separación':
-        targetScreen = const OrigenInicioScreen(); // TEMPORAL
+        OrigenUserConfig.current = OrigenUserConfig.planta;
+        targetScreen = const OrigenInicioScreen();
         break;
       case 'transformador':
         targetScreen = const OrigenInicioScreen(); // TEMPORAL


### PR DESCRIPTION
## Summary
- add `OrigenUserConfig` to share settings between origin user types
- route "Planta de Separación" through origin workflow with custom config
- use the config in origin screens and widgets

## Testing
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687959bbfcbc83228759a19705459f92