### PR TITLE
Remove header from recoger screen

### DIFF
--- a/lib/screens/ecoce/transporte/transporte_recoger_screen.dart
+++ b/lib/screens/ecoce/transporte/transporte_recoger_screen.dart
@@ -257,30 +257,22 @@ class _TransporteRecogerScreenState extends State<TransporteRecogerScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: BioWayColors.backgroundGrey,
-      appBar: AppBar(
-        backgroundColor: BioWayColors.deepBlue,
-        elevation: 0,
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back_ios, color: Colors.white),
-          onPressed: () {
-            HapticFeedback.lightImpact();
-            Navigator.pop(context);
-          },
-        ),
-        title: const Text(
-          'Formulario de Carga',
-          style: TextStyle(
-            fontSize: 20,
-            fontWeight: FontWeight.bold,
-            color: Colors.white,
-          ),
-        ),
-      ),
       body: Form(
         key: _formKey,
         child: SingleChildScrollView(
           child: Column(
             children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 20, 20, 10),
+                child: Text(
+                  'Formulario de Carga',
+                  style: TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                    color: BioWayColors.deepBlue,
+                  ),
+                ),
+              ),
               // Resumen de lotes seleccionados
               Container(
                 width: double.infinity,


### PR DESCRIPTION
## Summary
- redesign TransporteRecogerScreen by removing the `AppBar`
- add inline header text for the page
- verified `transporte_inicio_screen.dart` is still referenced and left untouched

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68795f801bec832280b2fef541173578