### PR TITLE
Remove bottom keyboard animation space

### DIFF
--- a/lib/screens/ecoce/origen/origen_crear_lote_screen.dart
+++ b/lib/screens/ecoce/origen/origen_crear_lote_screen.dart
@@ -464,8 +464,6 @@ class _OrigenCrearLoteScreenState extends State<OrigenCrearLoteScreen> {
                     ),
                     
                     const SizedBox(height: 20),
-                    // Espacio adicional para el teclado
-                    SizedBox(height: MediaQuery.of(context).viewInsets.bottom),
                   ],
                 ),
               ),


### PR DESCRIPTION
## Summary
- remove dynamic bottom padding in `origen_crear_lote_screen.dart` to avoid keyboard animation

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879c4d4811083228e5a7dd8d50ba59e